### PR TITLE
Fix GCC11 compilation issues

### DIFF
--- a/DemoApps/Shared/ObjectSelection/include/Shared/ObjectSelection/BoundingBoxUtil.hpp
+++ b/DemoApps/Shared/ObjectSelection/include/Shared/ObjectSelection/BoundingBoxUtil.hpp
@@ -34,6 +34,7 @@
 #include <FslBase/Math/BoundingBox.hpp>
 #include <FslBase/Math/Matrix.hpp>
 #include <vector>
+#include <limits>
 
 namespace Fsl
 {

--- a/DemoFramework/FslGraphics3D/SceneFormat/source/FslGraphics3D/SceneFormat/Conversion.cpp
+++ b/DemoFramework/FslGraphics3D/SceneFormat/source/FslGraphics3D/SceneFormat/Conversion.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <cassert>
 #include <vector>
+#include <limits>
 
 namespace Fsl
 {

--- a/DemoFramework/FslSimpleUI/Base/source/FslSimpleUI/Base/Layout/GridLayout.cpp
+++ b/DemoFramework/FslSimpleUI/Base/source/FslSimpleUI/Base/Layout/GridLayout.cpp
@@ -66,7 +66,7 @@ namespace Fsl
         m_definitionCache.HasEntriesX = true;
       }
 
-      return m_definitionsX.emplace_back(definition);
+      m_definitionsX.emplace_back(definition);
     }
 
     void GridLayout::AddRowDefinition(const GridRowDefinition& definition)
@@ -78,7 +78,7 @@ namespace Fsl
         m_definitionCache.HasEntriesY = true;
       }
 
-      return m_definitionsY.emplace_back(definition);
+      m_definitionsY.emplace_back(definition);
     }
 
 


### PR DESCRIPTION
GPU SDK fails to compile with recently released `GCC11`.

According to [GCC11 Porting Guide](https://gcc.gnu.org/gcc-11/porting_to.html), there are few modifications need to be included in the SDK to resolve compilation issues, namely:
- `std::numeric_limits` now require an explicit inclusion of <limits> header file
- Few functions in the code declared as `void` are returning values

This PR addresses those issues and makes SDK build compatible with GCC11.

-- andrey